### PR TITLE
Setenv to simple example

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,14 @@ The examples show different usage scenarios for the t7mp maven plugin.
 ## Simple ##
 
 This example shows how to use the plugin for rapid development. Primary the scanner feature is used to track changes
-in the webapplication. Any change to the webpage will be directly published to the server. This is really usefull
+in the webapplication. Any change to the webpage will be directly published to the server. This is really useful
 for web development. Is it not necessary to rebuild the project an restart the server to check the changes.
 
 * run with t7:run
-* stop with ctrl + c 
+* stop with ctrl + c
+
+The example shows also how to set different JVM args for tomcat than for maven. This feature works with the
+
+* t7:run-forked
+
+goal and used the setenv.sh (mac/unix) or setenv.bat (win) to set the JVM args.

--- a/simple/src/main/tomcat/bin/setenv.bat
+++ b/simple/src/main/tomcat/bin/setenv.bat
@@ -1,0 +1,1 @@
+set CATALINA_OPTS=-server -Dfile.encoding=UTF-8 -Djava.awt.headless=true -Xms1024m -Xmx1536m -XX:PermSize=256m -XX:MaxPermSize=512m -XX:+CMSClassUnloadingEnabled -Dcom.sun.management.jmxremote.port=7979 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dorg.apache.catalina.loader.WebappClassLoader.ENABLE_CLEAR_REFERENCES=false

--- a/simple/src/main/tomcat/bin/setenv.sh
+++ b/simple/src/main/tomcat/bin/setenv.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+CATALINA_OPTS="-server -Djava.awt.headless=true \
+			-Dfile.encoding=UTF-8 \
+			-Xms1024m -Xmx1536m \
+			-XX:NewSize=256m -XX:MaxNewSize=256m \
+			-XX:PermSize=256m -XX:MaxPermSize=512m \
+			-XX:+DisableExplicitGC \
+			-Dcom.sun.management.jmxremote.port=7979 \
+    		-Dcom.sun.management.jmxremote.ssl=false \
+    		-Dcom.sun.management.jmxremote.authenticate=false"

--- a/simple/src/main/webapp/index.jsp
+++ b/simple/src/main/webapp/index.jsp
@@ -1,9 +1,33 @@
 <html>
 <body>
-<h2>Simple Example for T7MP Maven Plugin</h2>
-<p>
-Shows how to use the t7mp plugin for rapid development. Every change in this file or any other webpage 
-will be directly available.
-</p>
+	<h2>Simple Example for T7MP Maven Plugin</h2>
+
+	<div class="fact">
+		<h3>Rapid Development</h3>
+		<p>Shows how to use the t7mp plugin for rapid development. Every
+			change in this file or any other webpage will be directly available.
+		</p>
+		<p>
+			This is reached with the
+			<code>scanners</code>
+			configuration
+		</p>
+		<p>
+			<code>
+				&lt;scanners&gt; <br>
+				  &nbsp; &lt;scannerConfiguration/&gt; <br/>
+				&lt;/scanners&gt;
+			</code>
+		</p>
+	</div>
+
+   <div class="fact">
+      <h3>Different JVM Agrs for Tomcat and Maven</h3>
+      <p>The Example show how to set JVM args for the tomcat process. This only works for the 
+         goal <code>t7:run-forked</code>. The arguments can be set with the setenv.sh (mac/unix) and 
+         setenv.bat (win) under <code>{basedir}/src/main/tomcat/bin</code> (this depends on the 
+         tomcatConfigDirectory configuration parameter).
+   </div>
+
 </body>
 </html>


### PR DESCRIPTION
Add setenv to set different JVM args for tomcat when started with t7:run-forked. This can also be seen as fix for Issue #10.
